### PR TITLE
Fix Netlify React Router page refresh Not Found

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Fixes the page refresh Not Found error we briefly discussed yesterday. Already applied and tested for ACAI deployment. 

For example compare https://acai.juliusai.dev/mission behavior with https://juliusai.dev/mission